### PR TITLE
Implement step 1 UI enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+build/
+pubspec.lock
+.flutter-plugins
+.flutter-plugins-dependencies
+.melos_tool
+.idea/
+.vscode/
+**/DerivedData/
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# 12vmm
+# 12-Week Mastery Planner
+
+En Flutter-app som hjälper dig att planera och följa upp mål under en 12-veckorsperiod. Projektet fokuserar på snabb interaktion med aktivitetslistor och tydlig progress i varje kategori.
+
+## Funktioner (Steg 1)
+- **Planerad/Klar-chippar i aktivitetsraderna** för att snabbt markera status vecka för vecka.
+- **Progresskort per kategori** med procent, progressbar och etiketten `klara/planerade`.
+- **Tomt-tillstånd med exempelchips** i mål- och aktivitetslistor så att du kan kickstarta utan att skriva.
+- **AnimatedSwitcher + “Ångra”-snackbar** vid borttagning av mål eller aktiviteter för mjuk feedback.
+
+## Kom igång
+1. Installera [Flutter](https://docs.flutter.dev/get-started/install).
+2. Kör `flutter pub get` i projektroten.
+3. Starta appen via `flutter run` eller bygg webben med `flutter run -d chrome`.
+
+## Testning
+- Kör `flutter test` för att verifiera widget- och enhetstester när de adderas.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true
+    avoid_print: true

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import 'screens/category_overview_screen.dart';
+
+class TwelveWeekApp extends StatelessWidget {
+  const TwelveWeekApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: '12+M',
+      debugShowCheckedModeBanner: false,
+      theme: _buildTheme(),
+      home: const CategoryOverviewScreen(),
+    );
+  }
+
+  ThemeData _buildTheme() {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: const Color(0xFF5E60CE),
+      brightness: Brightness.light,
+    );
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: const Color(0xFFF6F7FB),
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(milliseconds: 900),
+        backgroundColor: colorScheme.surface,
+        contentTextStyle: TextStyle(
+          color: colorScheme.onSurface,
+          fontWeight: FontWeight.w600,
+        ),
+        actionTextColor: colorScheme.primary,
+      ),
+      chipTheme: ChipThemeData.fromDefaults(
+        secondaryColor: colorScheme.primary,
+        primaryColor: colorScheme.primary,
+        brightness: Brightness.light,
+      ).copyWith(
+        labelStyle: TextStyle(
+          color: colorScheme.onSurface,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'app.dart';
+import 'state/app_state.dart';
+
+void main() {
+  runApp(
+    ChangeNotifierProvider<AppState>(
+      create: (_) => AppState(),
+      child: const TwelveWeekApp(),
+    ),
+  );
+}

--- a/lib/models/activity_model.dart
+++ b/lib/models/activity_model.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class ActivityModel {
+  ActivityModel({
+    required this.id,
+    required this.goalId,
+    required this.title,
+    Set<int>? plannedWeeks,
+    Set<int>? completedWeeks,
+  })  : plannedWeeks = plannedWeeks != null
+            ? Set<int>.from(plannedWeeks)
+            : <int>{},
+        completedWeeks = completedWeeks != null
+            ? Set<int>.from(completedWeeks)
+            : <int>{};
+
+  final String id;
+  final String goalId;
+  final String title;
+  final Set<int> plannedWeeks;
+  final Set<int> completedWeeks;
+
+  ActivityModel copy() => ActivityModel(
+        id: id,
+        goalId: goalId,
+        title: title,
+        plannedWeeks: plannedWeeks,
+        completedWeeks: completedWeeks,
+      );
+}

--- a/lib/models/category_model.dart
+++ b/lib/models/category_model.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class CategoryModel {
+  const CategoryModel({
+    required this.id,
+    required this.name,
+    required this.color,
+  });
+
+  final String id;
+  final String name;
+  final Color color;
+}

--- a/lib/models/goal_model.dart
+++ b/lib/models/goal_model.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class GoalModel {
+  const GoalModel({
+    required this.id,
+    required this.categoryId,
+    required this.title,
+  });
+
+  final String id;
+  final String categoryId;
+  final String title;
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,0 +1,3 @@
+export 'activity_model.dart';
+export 'category_model.dart';
+export 'goal_model.dart';

--- a/lib/screens/activity_list_screen.dart
+++ b/lib/screens/activity_list_screen.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/models.dart';
+import '../state/app_state.dart';
+import '../state/undo_action.dart';
+import '../widgets/activity_row.dart';
+import '../widgets/empty_state.dart';
+import '../widgets/week_stepper.dart';
+
+class ActivityListScreen extends StatelessWidget {
+  const ActivityListScreen({
+    super.key,
+    required this.goalId,
+  });
+
+  final String goalId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (context, state, _) {
+        final goal = state.goalById(goalId);
+        if (goal == null) {
+          return const Scaffold(
+            body: Center(child: Text('Målet hittades inte')), 
+          );
+        }
+        final activities = state.activitiesForGoal(goalId);
+        final currentWeek = state.currentWeek;
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(goal.title),
+          ),
+          body: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Veckoplan',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Markera vad som är planerat och klart den här veckan.',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodySmall
+                                ?.copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurfaceVariant,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    WeekStepper(
+                      week: currentWeek,
+                      onDecrement: state.decrementWeek,
+                      onIncrement: state.incrementWeek,
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 250),
+                  switchInCurve: Curves.easeOut,
+                  switchOutCurve: Curves.easeIn,
+                  child: activities.isEmpty
+                      ? EmptyState(
+                          key: const ValueKey('activity-empty'),
+                          icon: Icons.checklist_rtl,
+                          title: 'Inga aktiviteter planerade',
+                          subtitle:
+                              'Tips! Välj ett exempel nedan eller skapa din egen aktivitet. Du kan alltid lägga till fler senare.',
+                          suggestions: const <String>[
+                            '30 min bokläsning med barnen',
+                            'Kvällspromenad tisdag',
+                            'Planera veckans måltider',
+                          ],
+                          onSuggestionSelected: (suggestion) {
+                            state.addActivity(goalId, suggestion);
+                          },
+                        )
+                      : ListView.separated(
+                          key: ValueKey<int>(activities.length),
+                          padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                          itemBuilder: (context, index) {
+                            final activity = activities[index];
+                            final isPlanned =
+                                activity.plannedWeeks.contains(currentWeek);
+                            final isDone =
+                                activity.completedWeeks.contains(currentWeek);
+                            return ActivityRow(
+                              key: ValueKey<String>(activity.id),
+                              activity: activity,
+                              isPlanned: isPlanned,
+                              isDone: isDone,
+                              onTogglePlanned: () =>
+                                  state.toggleActivityPlanned(activity.id),
+                              onToggleDone: () =>
+                                  state.toggleActivityDone(activity.id),
+                              onRemove: () =>
+                                  _removeActivity(context, state, activity),
+                            );
+                          },
+                          separatorBuilder: (_, __) => const SizedBox(height: 12),
+                          itemCount: activities.length,
+                        ),
+                ),
+              ),
+            ],
+          ),
+          floatingActionButton: FloatingActionButton.extended(
+            onPressed: () => _showCreateActivityDialog(context),
+            label: const Text('Ny aktivitet'),
+            icon: const Icon(Icons.add_task),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showCreateActivityDialog(BuildContext context) async {
+    final controller = TextEditingController();
+    final theme = Theme.of(context);
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Lägg till aktivitet'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'Aktivitet',
+          ),
+          textInputAction: TextInputAction.done,
+          onSubmitted: (value) => Navigator.of(context).pop(value),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text('Avbryt', style: TextStyle(color: theme.colorScheme.onSurfaceVariant)),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(context).pop(controller.text);
+            },
+            child: const Text('Spara'),
+          ),
+        ],
+      ),
+    );
+    if (result != null) {
+      context.read<AppState>().addActivity(goalId, result);
+    }
+  }
+
+  void _removeActivity(
+    BuildContext context,
+    AppState state,
+    ActivityModel activity,
+  ) {
+    final undo = state.removeActivity(activity.id);
+    if (undo == null) {
+      return;
+    }
+    _showUndoSnackBar(
+      context,
+      message: '"${activity.title}" borttagen',
+      undo: undo,
+    );
+  }
+
+  void _showUndoSnackBar(
+    BuildContext context, {
+    required String message,
+    required UndoAction undo,
+  }) {
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    final state = context.read<AppState>();
+    scaffoldMessenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(message),
+          action: SnackBarAction(
+            label: 'Ångra',
+            onPressed: () => state.undo(undo),
+          ),
+        ),
+      );
+  }
+}

--- a/lib/screens/category_overview_screen.dart
+++ b/lib/screens/category_overview_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/models.dart';
+import '../state/app_state.dart';
+import '../widgets/category_card.dart';
+import 'goal_list_screen.dart';
+
+class CategoryOverviewScreen extends StatelessWidget {
+  const CategoryOverviewScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('12-veckors fokus'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 16, top: 12, bottom: 12),
+            child: Consumer<AppState>(
+              builder: (context, state, _) => Chip(
+                backgroundColor: theme.colorScheme.primaryContainer,
+                labelStyle: theme.textTheme.labelLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: theme.colorScheme.onPrimaryContainer,
+                ),
+                label: Text('Vecka ${state.currentWeek}'),
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Consumer<AppState>(
+          builder: (context, state, _) {
+            final categories = state.categories;
+            if (categories.isEmpty) {
+              return const Center(
+                child: Text('Lägg till en kategori för att komma igång'),
+              );
+            }
+            return ListView.separated(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+              itemCount: categories.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 16),
+              itemBuilder: (context, index) {
+                final category = categories[index];
+                final progress = state.progressForCategory(category.id);
+                return CategoryCard(
+                  key: ValueKey<String>(category.id),
+                  category: category,
+                  progress: progress,
+                  onTap: () => _openGoals(context, category),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _openGoals(BuildContext context, CategoryModel category) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => GoalListScreen(categoryId: category.id),
+      ),
+    );
+  }
+}

--- a/lib/screens/goal_list_screen.dart
+++ b/lib/screens/goal_list_screen.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/models.dart';
+import '../state/app_state.dart';
+import '../state/undo_action.dart';
+import '../widgets/empty_state.dart';
+import 'activity_list_screen.dart';
+
+class GoalListScreen extends StatelessWidget {
+  const GoalListScreen({
+    super.key,
+    required this.categoryId,
+  });
+
+  final String categoryId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (context, state, _) {
+        final category = state.categoryById(categoryId);
+        if (category == null) {
+          return const Scaffold(
+            body: Center(child: Text('Kategori saknas')),
+          );
+        }
+        final goals = state.goalsForCategory(categoryId);
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(category.name),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 250),
+              switchInCurve: Curves.easeOut,
+              switchOutCurve: Curves.easeIn,
+              child: goals.isEmpty
+                  ? EmptyState(
+                      key: const ValueKey('goal-empty'),
+                      icon: Icons.flag_outlined,
+                      title: 'Inga mål ännu',
+                      subtitle:
+                          'Skapa ett mål för den här kategorin eller välj ett exempel här nedanför.',
+                      suggestions: const <String>[
+                        'Starta morgonrutin',
+                        '80% veckoträning',
+                        'Mer energi till familjen',
+                      ],
+                      onSuggestionSelected: (suggestion) {
+                        state.addGoal(categoryId, suggestion);
+                      },
+                    )
+                  : ListView.separated(
+                      key: ValueKey<int>(goals.length),
+                      itemCount: goals.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      itemBuilder: (context, index) {
+                        final goal = goals[index];
+                        final progress = state.progressForGoal(goal.id);
+                        final ratioLabel = progress.planned == 0
+                            ? 'Ingen aktivitet planerad'
+                            : '${progress.completed}/${progress.planned} klara denna vecka';
+                        return Card(
+                          key: ValueKey<String>(goal.id),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: ListTile(
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 12,
+                            ),
+                            title: Text(
+                              goal.title,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleMedium
+                                  ?.copyWith(fontWeight: FontWeight.w700),
+                            ),
+                            subtitle: Text(
+                              ratioLabel,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                            trailing: Wrap(
+                              spacing: 4,
+                              children: [
+                                IconButton(
+                                  tooltip: 'Radera mål',
+                                  icon: const Icon(Icons.delete_outline),
+                                  onPressed: () =>
+                                      _removeGoal(context, state, goal),
+                                ),
+                                const Icon(Icons.chevron_right),
+                              ],
+                            ),
+                            onTap: () => _openActivities(context, goal),
+                          ),
+                        );
+                      },
+                    ),
+            ),
+          ),
+          floatingActionButton: FloatingActionButton.extended(
+            onPressed: () => _showCreateGoalDialog(context),
+            label: const Text('Nytt mål'),
+            icon: const Icon(Icons.add),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showCreateGoalDialog(BuildContext context) async {
+    final controller = TextEditingController();
+    final theme = Theme.of(context);
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Lägg till mål'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'Måltitel',
+          ),
+          textInputAction: TextInputAction.done,
+          onSubmitted: (value) => Navigator.of(context).pop(value),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text('Avbryt', style: TextStyle(color: theme.colorScheme.onSurfaceVariant)),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(context).pop(controller.text);
+            },
+            child: const Text('Spara'),
+          ),
+        ],
+      ),
+    );
+    if (result != null) {
+      final state = context.read<AppState>();
+      state.addGoal(categoryId, result);
+    }
+  }
+
+  void _openActivities(BuildContext context, GoalModel goal) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => ActivityListScreen(goalId: goal.id),
+      ),
+    );
+  }
+
+  void _removeGoal(BuildContext context, AppState state, GoalModel goal) {
+    final undo = state.removeGoal(goal.id);
+    if (undo == null) {
+      return;
+    }
+    _showUndoSnackBar(
+      context,
+      message: '"${goal.title}" borttagen',
+      undo: undo,
+    );
+  }
+
+  void _showUndoSnackBar(
+    BuildContext context, {
+    required String message,
+    required UndoAction undo,
+  }) {
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    final state = context.read<AppState>();
+    scaffoldMessenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(message),
+          action: SnackBarAction(
+            label: 'Ångra',
+            onPressed: () => state.undo(undo),
+          ),
+        ),
+      );
+  }
+}

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1,0 +1,348 @@
+import 'dart:collection';
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import 'undo_action.dart';
+
+@immutable
+class CategoryProgress {
+  const CategoryProgress({
+    required this.planned,
+    required this.completed,
+  });
+
+  final int planned;
+  final int completed;
+
+  double get percent => planned == 0 ? 0 : completed / planned;
+}
+
+@immutable
+class GoalProgress {
+  const GoalProgress({
+    required this.planned,
+    required this.completed,
+  });
+
+  final int planned;
+  final int completed;
+
+  double get percent => planned == 0 ? 0 : completed / planned;
+}
+
+class AppState extends ChangeNotifier {
+  AppState() {
+    _seed();
+  }
+
+  final List<CategoryModel> _categories = <CategoryModel>[];
+  final List<GoalModel> _goals = <GoalModel>[];
+  final List<ActivityModel> _activities = <ActivityModel>[];
+
+  int _currentWeek = 1;
+
+  int get currentWeek => _currentWeek;
+
+  UnmodifiableListView<CategoryModel> get categories =>
+      UnmodifiableListView<CategoryModel>(_categories);
+
+  CategoryModel? categoryById(String id) =>
+      _categories.firstWhereOrNull((category) => category.id == id);
+
+  GoalModel? goalById(String id) =>
+      _goals.firstWhereOrNull((goal) => goal.id == id);
+
+  List<GoalModel> goalsForCategory(String categoryId) => _goals
+      .where((goal) => goal.categoryId == categoryId)
+      .toList(growable: false);
+
+  List<ActivityModel> activitiesForGoal(String goalId) => _activities
+      .where((activity) => activity.goalId == goalId)
+      .toList(growable: false);
+
+  CategoryProgress progressForCategory(String categoryId) {
+    final goalIds = _goals
+        .where((goal) => goal.categoryId == categoryId)
+        .map((goal) => goal.id)
+        .toSet();
+    if (goalIds.isEmpty) {
+      return const CategoryProgress(planned: 0, completed: 0);
+    }
+    var planned = 0;
+    var completed = 0;
+    for (final activity in _activities) {
+      if (!goalIds.contains(activity.goalId)) {
+        continue;
+      }
+      if (activity.plannedWeeks.contains(_currentWeek)) {
+        planned += 1;
+      }
+      if (activity.completedWeeks.contains(_currentWeek)) {
+        completed += 1;
+      }
+    }
+    return CategoryProgress(planned: planned, completed: completed);
+  }
+
+  GoalProgress progressForGoal(String goalId) {
+    final activities = activitiesForGoal(goalId);
+    if (activities.isEmpty) {
+      return const GoalProgress(planned: 0, completed: 0);
+    }
+    var planned = 0;
+    var completed = 0;
+    for (final activity in activities) {
+      if (activity.plannedWeeks.contains(_currentWeek)) {
+        planned += 1;
+      }
+      if (activity.completedWeeks.contains(_currentWeek)) {
+        completed += 1;
+      }
+    }
+    return GoalProgress(planned: planned, completed: completed);
+  }
+
+  void setCurrentWeek(int week) {
+    final clamped = math.max(1, math.min(12, week));
+    if (clamped == _currentWeek) {
+      return;
+    }
+    _currentWeek = clamped;
+    notifyListeners();
+  }
+
+  void incrementWeek() => setCurrentWeek(_currentWeek + 1);
+
+  void decrementWeek() => setCurrentWeek(_currentWeek - 1);
+
+  void toggleActivityPlanned(String activityId) {
+    final activity =
+        _activities.firstWhereOrNull((item) => item.id == activityId);
+    if (activity == null) {
+      return;
+    }
+    if (activity.plannedWeeks.contains(_currentWeek)) {
+      activity.plannedWeeks.remove(_currentWeek);
+      activity.completedWeeks.remove(_currentWeek);
+    } else {
+      activity.plannedWeeks.add(_currentWeek);
+    }
+    notifyListeners();
+  }
+
+  void toggleActivityDone(String activityId) {
+    final activity =
+        _activities.firstWhereOrNull((item) => item.id == activityId);
+    if (activity == null) {
+      return;
+    }
+    if (activity.completedWeeks.contains(_currentWeek)) {
+      activity.completedWeeks.remove(_currentWeek);
+    } else {
+      activity.plannedWeeks.add(_currentWeek);
+      activity.completedWeeks.add(_currentWeek);
+    }
+    notifyListeners();
+  }
+
+  GoalModel? addGoal(String categoryId, String title) {
+    final trimmed = title.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    final goal = GoalModel(
+      id: _generateId('goal'),
+      categoryId: categoryId,
+      title: trimmed,
+    );
+    _goals.add(goal);
+    notifyListeners();
+    return goal;
+  }
+
+  ActivityModel? addActivity(String goalId, String title) {
+    final trimmed = title.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    final activity = ActivityModel(
+      id: _generateId('act'),
+      goalId: goalId,
+      title: trimmed,
+    );
+    _activities.add(activity);
+    notifyListeners();
+    return activity;
+  }
+
+  UndoAction? removeGoal(String goalId) {
+    final index = _goals.indexWhere((goal) => goal.id == goalId);
+    if (index == -1) {
+      return null;
+    }
+    final goal = _goals.removeAt(index);
+    final removedActivities = _activities
+        .where((activity) => activity.goalId == goalId)
+        .map((activity) => activity.copy())
+        .toList(growable: false);
+    _activities.removeWhere((activity) => activity.goalId == goalId);
+    notifyListeners();
+    return UndoAction.goal(
+      goal: goal,
+      goalIndex: index,
+      activities: removedActivities,
+    );
+  }
+
+  UndoAction? removeActivity(String activityId) {
+    final index =
+        _activities.indexWhere((activity) => activity.id == activityId);
+    if (index == -1) {
+      return null;
+    }
+    final removed = _activities.removeAt(index);
+    notifyListeners();
+    return UndoAction.activity(
+      activity: removed.copy(),
+      activityIndex: index,
+    );
+  }
+
+  void undo(UndoAction? action) {
+    if (action == null) {
+      return;
+    }
+    switch (action.type) {
+      case UndoType.goal:
+        final goal = action.goal;
+        if (goal == null) {
+          return;
+        }
+        if (_goals.any((existing) => existing.id == goal.id)) {
+          return;
+        }
+        final index = action.goalIndex ?? _goals.length;
+        final safeIndex = math.min(math.max(index, 0), _goals.length);
+        _goals.insert(safeIndex, goal);
+        for (final activity in action.activities) {
+          if (_activities.any((existing) => existing.id == activity.id)) {
+            continue;
+          }
+          _activities.add(activity.copy());
+        }
+        notifyListeners();
+        break;
+      case UndoType.activity:
+        final activity = action.activity;
+        if (activity == null) {
+          return;
+        }
+        if (_activities.any((existing) => existing.id == activity.id)) {
+          return;
+        }
+        final index = action.activityIndex ?? _activities.length;
+        final safeIndex = math.min(math.max(index, 0), _activities.length);
+        _activities.insert(safeIndex, activity.copy());
+        notifyListeners();
+        break;
+    }
+  }
+
+  String _generateId(String prefix) =>
+      '$prefix-${DateTime.now().microsecondsSinceEpoch}';
+
+  void _seed() {
+    _categories.addAll(const <CategoryModel>[
+      CategoryModel(
+        id: 'cat-health',
+        name: 'Hälsa',
+        color: Color(0xFFB9FBC0),
+      ),
+      CategoryModel(
+        id: 'cat-family',
+        name: 'Familj',
+        color: Color(0xFFFFE0B2),
+      ),
+      CategoryModel(
+        id: 'cat-career',
+        name: 'Karriär',
+        color: Color(0xFFD0BCFF),
+      ),
+    ]);
+
+    _goals.addAll(const <GoalModel>[
+      GoalModel(
+        id: 'goal-run',
+        categoryId: 'cat-health',
+        title: 'Springa 5 km utan stopp',
+      ),
+      GoalModel(
+        id: 'goal-strength',
+        categoryId: 'cat-health',
+        title: 'Bygga vardagsstyrka',
+      ),
+      GoalModel(
+        id: 'goal-family',
+        categoryId: 'cat-family',
+        title: 'Familjekväll varje vecka',
+      ),
+      GoalModel(
+        id: 'goal-learning',
+        categoryId: 'cat-career',
+        title: 'Skapa demo-app i Flutter',
+      ),
+    ]);
+
+    _activities.addAll(<ActivityModel>[
+      ActivityModel(
+        id: 'act-intervals',
+        goalId: 'goal-run',
+        title: 'Intervaller 20 min',
+        plannedWeeks: {1, 2, 3},
+        completedWeeks: {1},
+      ),
+      ActivityModel(
+        id: 'act-longrun',
+        goalId: 'goal-run',
+        title: 'Långpass söndag',
+        plannedWeeks: {1, 2},
+        completedWeeks: {1},
+      ),
+      ActivityModel(
+        id: 'act-strength-home',
+        goalId: 'goal-strength',
+        title: 'Hemma styrka 30 min',
+        plannedWeeks: {1, 2, 3},
+        completedWeeks: {1},
+      ),
+      ActivityModel(
+        id: 'act-mobility',
+        goalId: 'goal-strength',
+        title: 'Rörlighet & stretch',
+        plannedWeeks: {1, 2},
+      ),
+      ActivityModel(
+        id: 'act-family-night',
+        goalId: 'goal-family',
+        title: 'Fredagsmys utan skärmar',
+        plannedWeeks: {1, 2, 3},
+        completedWeeks: {1},
+      ),
+      ActivityModel(
+        id: 'act-walk',
+        goalId: 'goal-family',
+        title: 'Söndagspromenad',
+        plannedWeeks: {1, 2},
+      ),
+      ActivityModel(
+        id: 'act-learning',
+        goalId: 'goal-learning',
+        title: 'Animation-kurs 45 min',
+        plannedWeeks: {1},
+      ),
+    ]);
+  }
+}

--- a/lib/state/undo_action.dart
+++ b/lib/state/undo_action.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+
+enum UndoType { goal, activity }
+
+@immutable
+class UndoAction {
+  const UndoAction.goal({
+    required this.goal,
+    required this.goalIndex,
+    required this.activities,
+  })  : type = UndoType.goal,
+        activity = null,
+        activityIndex = null;
+
+  const UndoAction.activity({
+    required this.activity,
+    required this.activityIndex,
+  })  : type = UndoType.activity,
+        goal = null,
+        goalIndex = null,
+        activities = const <ActivityModel>[];
+
+  final UndoType type;
+  final GoalModel? goal;
+  final int? goalIndex;
+  final List<ActivityModel> activities;
+  final ActivityModel? activity;
+  final int? activityIndex;
+}

--- a/lib/widgets/activity_row.dart
+++ b/lib/widgets/activity_row.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import '../models/activity_model.dart';
+
+class ActivityRow extends StatelessWidget {
+  const ActivityRow({
+    super.key,
+    required this.activity,
+    required this.isPlanned,
+    required this.isDone,
+    required this.onTogglePlanned,
+    required this.onToggleDone,
+    required this.onRemove,
+  });
+
+  final ActivityModel activity;
+  final bool isPlanned;
+  final bool isDone;
+  final VoidCallback onTogglePlanned;
+  final VoidCallback onToggleDone;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              activity.title,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Wrap(
+                    spacing: 10,
+                    runSpacing: 10,
+                    children: [
+                      FilterChip(
+                        label: const Text('Planerad'),
+                        selected: isPlanned,
+                        onSelected: (_) => onTogglePlanned(),
+                      ),
+                      FilterChip(
+                        label: const Text('Klar'),
+                        selected: isDone,
+                        onSelected: (_) => onToggleDone(),
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Radera aktivitet',
+                  onPressed: onRemove,
+                  icon: const Icon(Icons.delete_outline),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/category_card.dart
+++ b/lib/widgets/category_card.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../state/app_state.dart';
+
+class CategoryCard extends StatelessWidget {
+  const CategoryCard({
+    super.key,
+    required this.category,
+    required this.progress,
+    required this.onTap,
+  });
+
+  final CategoryModel category;
+  final CategoryProgress progress;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final percent = progress.percent.clamp(0.0, 1.0);
+    final ratioLabel = progress.planned == 0
+        ? '0 planerade'
+        : '${progress.completed}/${progress.planned} klara';
+
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 0,
+      color: category.color.withOpacity(0.22),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(18),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                category.name,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: theme.colorScheme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 18),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    '${(percent * 100).round()}%',
+                    style: theme.textTheme.displaySmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(999),
+                          child: LinearProgressIndicator(
+                            value: percent,
+                            minHeight: 6,
+                            backgroundColor:
+                                theme.colorScheme.surfaceVariant.withOpacity(0.5),
+                            color: theme.colorScheme.primary,
+                          ),
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          ratioLabel,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/empty_state.dart
+++ b/lib/widgets/empty_state.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+class EmptyState extends StatelessWidget {
+  const EmptyState({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.suggestions,
+    required this.onSuggestionSelected,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final List<String> suggestions;
+  final ValueChanged<String> onSuggestionSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 48, color: theme.colorScheme.primary),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: theme.colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              subtitle,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (suggestions.isNotEmpty) ...[
+              const SizedBox(height: 20),
+              Wrap(
+                alignment: WrapAlignment.center,
+                spacing: 12,
+                runSpacing: 12,
+                children: suggestions
+                    .map(
+                      (suggestion) => ActionChip(
+                        label: Text(suggestion),
+                        onPressed: () => onSuggestionSelected(suggestion),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/week_stepper.dart
+++ b/lib/widgets/week_stepper.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class WeekStepper extends StatelessWidget {
+  const WeekStepper({
+    super.key,
+    required this.week,
+    required this.onDecrement,
+    required this.onIncrement,
+  });
+
+  final int week;
+  final VoidCallback onDecrement;
+  final VoidCallback onIncrement;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            tooltip: 'Föregående vecka',
+            icon: const Icon(Icons.chevron_left),
+            onPressed: week > 1 ? onDecrement : null,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Text(
+              'Vecka $week',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+          ),
+          IconButton(
+            tooltip: 'Nästa vecka',
+            icon: const Icon(Icons.chevron_right),
+            onPressed: week < 12 ? onIncrement : null,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,21 @@
+name: twelve_week_mastery
+description: 12-week mastery planner application.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.1.2
+  collection: ^1.18.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.2
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold a Flutter app with categories, goals, and activities for the 12-week planner
- add planerad/klar chips, progress cards, and guided empty states per step 1 requirements
- implement undoable removals and shared state management to drive the new interactions

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9c6050f8883248ec7168c96649dc5